### PR TITLE
Fixes the Folder.WellKnownFolderName property

### DIFF
--- a/Core/ServiceObjects/Folders/Folder.cs
+++ b/Core/ServiceObjects/Folders/Folder.cs
@@ -666,9 +666,9 @@ namespace Microsoft.Exchange.WebServices.Data
         /// Gets the name of the well known folder.
         /// </summary>
         /// <value>The name of the well known folder.</value>
-        public WellKnownFolderName? WellKnownFolderName
+        public string WellKnownFolderName
         {
-            get { return (WellKnownFolderName?)this.PropertyBag[FolderSchema.WellKnownFolderName]; }
+            get { return (string)this.PropertyBag[FolderSchema.WellKnownFolderName]; }
         }
 
         #endregion

--- a/Core/ServiceObjects/Schemas/FolderSchema.cs
+++ b/Core/ServiceObjects/Schemas/FolderSchema.cs
@@ -166,17 +166,16 @@ namespace Microsoft.Exchange.WebServices.Data
                 PropertyDefinitionFlags.AutoInstantiateOnRead | PropertyDefinitionFlags.CanSet | PropertyDefinitionFlags.CanUpdate | PropertyDefinitionFlags.CanDelete | PropertyDefinitionFlags.MustBeExplicitlyLoaded,
                 ExchangeVersion.Exchange2007_SP1);
 
-        /// <summary>
-        /// Defines the WellKnownFolderName property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Immutable type")]
-        public static readonly PropertyDefinition WellKnownFolderName =
-            new GenericPropertyDefinition<WellKnownFolderName>(
-                XmlElementNames.DistinguishedFolderId,
-                FieldUris.DistinguishedFolderId,
-                PropertyDefinitionFlags.CanSet | PropertyDefinitionFlags.CanFind,
-                ExchangeVersion.Exchange2013,
-                true);
+		/// <summary>
+		/// Defines the WellKnownFolderName property.
+		/// </summary>
+		[SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Immutable type")]
+		public static readonly PropertyDefinition WellKnownFolderName =
+			new StringPropertyDefinition(
+				XmlElementNames.DistinguishedFolderId,
+				FieldUris.DistinguishedFolderId,
+				PropertyDefinitionFlags.CanSet | PropertyDefinitionFlags.CanFind,
+				ExchangeVersion.Exchange2013);
 
         /// <summary>
         /// Defines the PolicyTag property.

--- a/Microsoft.Exchange.WebServices.Data.csproj
+++ b/Microsoft.Exchange.WebServices.Data.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Exchange.WebServices.Data</RootNamespace>
-    <AssemblyName>Microsoft.Exchange.WebServices.Data</AssemblyName>
+    <AssemblyName>Microsoft.Exchange.WebServices</AssemblyName>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>4.0</OldToolsVersion>
@@ -42,7 +42,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Microsoft.Exchange.WebServices.Data.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\Microsoft.Exchange.WebServices.xml</DocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
The Folder.WellKnownFolderName property is currently of type WellKnownFolderName?

This is a problem if well known folder names as defined in the WellKnownFolderName enumeration do not match that in the DistinguishedFolderIdNameType type in the EWS schema. If a well known folder name that is unknown to the API is received from the server, the API will crash.

This fix makes the property a string, which will prevent crashes while still providing the added convenience.

This pull request also fixes the assembly name in the project properties (changed to Microsoft.Exchange.WebServices from Microsoft.Exchange.WebServices.Data)