### PR TITLE
KeyNotFoundException in DictionaryProperty.cs

### DIFF
--- a/ComplexProperties/DictionaryProperty.cs
+++ b/ComplexProperties/DictionaryProperty.cs
@@ -212,13 +212,13 @@ namespace Microsoft.Exchange.WebServices.Data
                 entry.OnChange -= this.EntryChanged;
 
                 this.entries.Remove(key);
-				this.modifiedEntries.Remove (key);
                 this.removedEntries.Add(key, entry);
 
                 this.Changed();
             }
 
             this.addedEntries.Remove(key);
+            this.modifiedEntries.Remove (key);
         }
 
         /// <summary>

--- a/ComplexProperties/DictionaryProperty.cs
+++ b/ComplexProperties/DictionaryProperty.cs
@@ -212,6 +212,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 entry.OnChange -= this.EntryChanged;
 
                 this.entries.Remove(key);
+				this.modifiedEntries.Remove (key);
                 this.removedEntries.Add(key, entry);
 
                 this.Changed();


### PR DESCRIPTION
Bugfix: KeyNotFoundException

When you add, update, delete the email addresses of a contact without sending it to the server after every modification, it happens that "modifiedEntries" still contains the key, for example "EmailAddress2", which is also in "removedEntries", because the contact has recently been deleted.

This patch removed the key from "modifiedEntries" when the entry is deleted.