### PR TITLE
Two bug fixes:

### DIFF
--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -343,11 +343,6 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <param name="headers">The response headers</param>
         private void SaveHttpResponseHeaders(WebHeaderCollection headers)
         {
-            EwsUtilities.Assert(
-                this.httpResponseHeaders.Count == 0,
-                "ExchangeServiceBase.SaveHttpResponseHeaders",
-                "expect no headers in the dictionary yet.");
-            
             this.httpResponseHeaders.Clear();
 
             foreach (string key in headers.AllKeys)

--- a/Core/ServiceObjects/Items/Conversation.cs
+++ b/Core/ServiceObjects/Items/Conversation.cs
@@ -138,16 +138,6 @@ namespace Microsoft.Exchange.WebServices.Data
             throw new NotSupportedException();
         }
 
-        /// <summary>
-        /// This method is not supported in this object.
-        /// Gets the extended properties collection.
-        /// </summary>
-        /// <returns>Extended properties collection.</returns>
-        internal override ExtendedPropertyCollection GetExtendedProperties()
-        {
-            throw new NotSupportedException();
-        }
-
         #endregion
 
         #region Conversation Action Methods


### PR DESCRIPTION
- Removes unnecessary Assert in ExchangeServiceBase.SaveHttpResponseHeaders
- Removes GetExtendedProperties override in Conversation so it returns null instead of throwing