### PR TITLE
Enable travis support for ews-managed-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+#
+#  Exchange Web Services Managed API
+#
+#  Copyright (c) Microsoft Corporation
+#  All rights reserved.
+# 
+#  MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+#  software and associated documentation files (the "Software"), to deal in the Software
+#  without restriction, including without limitation the rights to use, copy, modify, merge,
+#  publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+#  to whom the Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all copies or
+#  substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+#  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+#  PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+#  FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+#  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+#
+
+language: csharp
+solution: Microsoft.Exchange.WebServices.Data.sln
+
+# enable container-based infrastructure
+sudo: false
+
+mono:
+  - latest

--- a/Autodiscover/DirectoryHelper.cs
+++ b/Autodiscover/DirectoryHelper.cs
@@ -360,15 +360,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
                     return site.Name;
                 }
             }
-            catch (ActiveDirectoryObjectNotFoundException)  // object not found in directory store
-            {
-                return null;
-            }
-            catch (ActiveDirectoryOperationException)       // underlying directory operation failed
-            {
-                return null;
-            }
-            catch (ActiveDirectoryServerDownException)      // server unavailable
+            catch (Exception)
             {
                 return null;
             }

--- a/Microsoft.Exchange.WebServices.Data.sln
+++ b/Microsoft.Exchange.WebServices.Data.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8BBBEC00-BD81-4F37-A855-D338DC01E1C5}"
 	ProjectSection(SolutionItems) = preProject
+		.travis.yml = .travis.yml
 		CONTRIBUTING.md = CONTRIBUTING.md
 		license.txt = license.txt
 		README.md = README.md


### PR DESCRIPTION
Note:
Travis supports c# projects only in a beta phase. So maybe a longterm solution for ci might be keeping on with the evaluation mentioned in #31. 

I have also seen other projects around having a travis.yml setup with objective-c and a manually installed mono which might also be an option.

Unfortunately travis didn#t like the 'ActiveDirectoryObjectNotFoundException' which results in a `error CS0246: The type or namespace name `ActiveDirectoryObjectNotFoundException' could not be found. Are you missing an assembly reference?` Adding a more general try / catch solved the problem so far but as I am not that C# specialist maybe there is a better solution for this.

Changing the `VisualStudioVersion` was done automatically. If needed I can revert this.