### PR TITLE
Fix typos in comments, XML docs and messages

### DIFF
--- a/Autodiscover/AutodiscoverService.cs
+++ b/Autodiscover/AutodiscoverService.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
             }
 
             // Assume caller is not inside the Intranet, regardless of whether SCP Urls 
-            // were returned or not. SCP Urls are only relevent if one of them returns
+            // were returned or not. SCP Urls are only relevant if one of them returns
             // valid Autodiscover settings.
             this.isExternal = true;
 
@@ -539,7 +539,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
                             EwsUtilities.Assert(
                                 false,
                                 "Autodiscover.GetConfigurationSettings",
-                                "An unexpected error has occured. This code path should never be reached.");
+                                "An unexpected error has occurred. This code path should never be reached.");
                             break;
                     }
                 }

--- a/Autodiscover/DirectoryHelper.cs
+++ b/Autodiscover/DirectoryHelper.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
                             // Stop the current search, start another from a new location.
                             this.TraceMessage(
                                 string.Format(
-                                    "SCP pointer for '{0}' is found in '{1}', restarting seach in '{2}'",
+                                    "SCP pointer for '{0}' is found in '{1}', restarting search in '{2}'",
                                     domainMatch,
                                     scpDirEntry.Path,
                                     scpPtrLdapPath));

--- a/ComplexProperties/AppointmentOccurrenceId.cs
+++ b/ComplexProperties/AppointmentOccurrenceId.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Exchange.WebServices.Data
 
             set
             {
-                // The occurence index has to be positive integer.
+                // The occurrence index has to be positive integer.
                 if (value < 1)
                 {
                     throw new ArgumentException(Strings.OccurrenceIndexMustBeGreaterThanZero);

--- a/Core/Requests/CreateUserConfigurationRequest.cs
+++ b/Core/Requests/CreateUserConfigurationRequest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <param name="writer">The writer.</param>
         internal override void WriteElementsToXml(EwsServiceXmlWriter writer)
         {
-            // Write UserConfiguation element
+            // Write UserConfiguration element
             this.userConfiguration.WriteToXml(writer, XmlNamespace.Messages, XmlElementNames.UserConfiguration);
         }
 

--- a/Core/Requests/DeleteUserConfigurationRequest.cs
+++ b/Core/Requests/DeleteUserConfigurationRequest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <param name="writer">The writer.</param>
         internal override void WriteElementsToXml(EwsServiceXmlWriter writer)
         {
-            // Write UserConfiguationName element
+            // Write UserConfigurationName element
             UserConfiguration.WriteUserConfigurationNameToXml(
                 writer,
                 XmlNamespace.Messages,

--- a/Core/Requests/MultiResponseServiceRequest.cs
+++ b/Core/Requests/MultiResponseServiceRequest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Exchange.WebServices.Data
             // If there's a general error in batch processing,
             // the server will return a single response message containing the error
             // (for example, if the SavedItemFolderId is bogus in a batch CreateItem
-            // call). In this case, throw a ServiceResponsException. Otherwise this 
+            // call). In this case, throw a ServiceResponseException. Otherwise this 
             // is an unexpected server error.
             if (serviceResponses.Count < this.GetExpectedResponseMessageCount())
             {

--- a/Core/Requests/SearchMailboxesRequest.cs
+++ b/Core/Requests/SearchMailboxesRequest.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 writer.WriteStartElement(XmlNamespace.Types, XmlElementNames.MailboxSearchScopes);
                 foreach (MailboxSearchScope mailboxSearchScope in mailboxQuery.MailboxSearchScopes)
                 {
-                    // The checks here silently downgrade the schema based on compatability checks, to recieve errors use the validate method
+                    // The checks here silently downgrade the schema based on compatibility checks, to receive errors use the validate method
                     if (mailboxSearchScope.SearchScopeType == MailboxSearchScopeType.LegacyExchangeDN || DiscoverySchemaChanges.SearchMailboxesAdditionalSearchScopes.IsCompatible(this))
                     {
                         writer.WriteStartElement(XmlNamespace.Types, XmlElementNames.MailboxSearchScope);

--- a/Core/Requests/ServiceRequestBase.cs
+++ b/Core/Requests/ServiceRequestBase.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Exchange.WebServices.Data
             // there is little perf gain with this approach because of EWS's message nature.
             // The overall latency of BeginGetRequestStream() is same as GetRequestStream() in this case.
             // The overhead to implement a two-step async operation includes wait handle synchronization, exception handling and wrapping.
-            // Therefore, we only leverage BeginGetResponse() and EndGetReponse() to provide the async functionality.
+            // Therefore, we only leverage BeginGetResponse() and EndGetResponse() to provide the async functionality.
             // Reference: http://www.wintellect.com/CS/blogs/jeffreyr/archive/2009/02/08/httpwebrequest-its-request-stream-and-sending-data-in-chunks.aspx
             return request.EndGetRequestStream(request.BeginGetRequestStream(null, null));
         }

--- a/Core/Requests/UpdateItemRequest.cs
+++ b/Core/Requests/UpdateItemRequest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Exchange.WebServices.Data
         }
 
         /// <summary>
-        /// Gets a value indicating whether the TimeZoneContext SOAP header should be eimitted.
+        /// Gets a value indicating whether the TimeZoneContext SOAP header should be emitted.
         /// </summary>
         /// <value>
         ///     <c>true</c> if the time zone should be emitted; otherwise, <c>false</c>.
@@ -62,7 +62,7 @@ namespace Microsoft.Exchange.WebServices.Data
             {
                 foreach (Item item in this.Items)
                 {
-                    if (item.GetIsTimeZoneHeaderRequired(true /* isUpdateOpeartion */))
+                    if (item.GetIsTimeZoneHeaderRequired(true /* isUpdateOperation */))
                     {
                         return true;
                     }

--- a/Core/Requests/UpdateUserConfigurationRequest.cs
+++ b/Core/Requests/UpdateUserConfigurationRequest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <param name="writer">The writer.</param>
         internal override void WriteElementsToXml(EwsServiceXmlWriter writer)
         {
-            // Write UserConfiguation element
+            // Write UserConfiguration element
             this.userConfiguration.WriteToXml(writer, XmlNamespace.Messages, XmlElementNames.UserConfiguration);
         }
 

--- a/Core/ServiceObjects/Items/EmailMessage.cs
+++ b/Core/ServiceObjects/Items/EmailMessage.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Exchange.WebServices.Data
         }
 
         /// <summary>
-        /// Gets the Internat Message Id of the e-mail message.
+        /// Gets the Internet Message Id of the e-mail message.
         /// </summary>
         public string InternetMessageId
         {

--- a/Dns/DnsClient.cs
+++ b/Dns/DnsClient.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Exchange.WebServices.Dns
             // Each strongly-typed DnsRecord type maps to a DnsRecordType enum.
             DnsRecordType dnsRecordTypeToQuery = typeToDnsTypeMap.Member[typeof(T)];
 
-            // queryResultsPtr will point to unmanaged heap memoery if DnsQuery succeeds.
+            // queryResultsPtr will point to unmanaged heap memory if DnsQuery succeeds.
             IntPtr queryResultsPtr = IntPtr.Zero;
 
             try


### PR DESCRIPTION
This fixes a few typos in comments, XML documentation and trace/assert messages.