### PR TITLE
Add new ExchangeVersionType values

### DIFF
--- a/Enumerations/ExchangeVersion.cs
+++ b/Enumerations/ExchangeVersion.cs
@@ -63,8 +63,18 @@ namespace Microsoft.Exchange.WebServices.Data
         Exchange2013_SP1 = 5,
 
         /// <summary>
-        /// Microsoft Exchange 2015
+        /// Microsoft Exchange 2015 (aka Exchange 2016)
         /// </summary>
         Exchange2015 = 6,
+
+        /// <summary>
+        /// Microsoft Exchange 2016
+        /// </summary>
+        Exchange2016 = 7,
+
+        /// <summary>
+        /// Functionality starting 10/05/2015
+        /// </summary>
+        V2015_10_05 = 8,
     }
 }


### PR DESCRIPTION
We have rev'd the schema in the service and need to reflect these
changes in the client API.  This is the first change.  Note that
Exchange2015 and Exchange2016 represent the same version.  We gave the
schema the name Exchange2015 before we knew what the shipped product
name would be.  Note that we have changed the format of our versioning
identifiers as can be surmised by looking at the newest value in the
enum.