### PR TITLE
Ability to reuse connections with NTLM authentication

### DIFF
--- a/Core/EwsHttpWebRequest.cs
+++ b/Core/EwsHttpWebRequest.cs
@@ -293,6 +293,15 @@ namespace Microsoft.Exchange.WebServices.Data
             set { this.request.ConnectionGroupName = value; }
         }
 
+        /// <summary>
+        /// Gets or sets if the request to the internet resource should allow high-speed NTLM-authenticated connection sharing
+        /// </summary>
+        public bool UnsafeAuthenticatedConnectionSharing
+        {
+            get { return this.request.UnsafeAuthenticatedConnectionSharing; }
+            set { this.request.UnsafeAuthenticatedConnectionSharing = value; }
+        }
+
         #endregion
     }
 }

--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Exchange.WebServices.Data
         private string userAgent = ExchangeService.defaultUserAgent;
         private bool acceptGzipEncoding = true;
         private bool keepAlive = true;
+        private bool unsafeAuthenticatedConnectionSharing;
         private string connectionGroupName;
         private string clientRequestId;
         private bool returnClientRequestId;
@@ -146,6 +147,7 @@ namespace Microsoft.Exchange.WebServices.Data
             request.AllowAutoRedirect = allowAutoRedirect;
             request.CookieContainer = this.CookieContainer;
             request.KeepAlive = this.keepAlive;
+            request.UnsafeAuthenticatedConnectionSharing = this.unsafeAuthenticatedConnectionSharing;
             request.ConnectionGroupName = this.connectionGroupName;
 
             if (acceptGzipEncoding)
@@ -545,6 +547,7 @@ namespace Microsoft.Exchange.WebServices.Data
             this.userAgent = service.userAgent;
             this.acceptGzipEncoding = service.acceptGzipEncoding;
             this.keepAlive = service.keepAlive;
+            this.unsafeAuthenticatedConnectionSharing = service.unsafeAuthenticatedConnectionSharing;
             this.connectionGroupName = service.connectionGroupName;
             this.timeZone = service.timeZone;
             this.httpHeaders = service.httpHeaders;
@@ -819,6 +822,22 @@ namespace Microsoft.Exchange.WebServices.Data
             set
             {
                 this.keepAlive = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if the request to the internet resource should allow high-speed NTLM-authenticated connection sharing
+        /// </summary>
+        public bool UnsafeAuthenticatedConnectionSharing
+        {
+            get
+            {
+                return this.unsafeAuthenticatedConnectionSharing;
+            }
+
+            set
+            {
+                this.unsafeAuthenticatedConnectionSharing = value;
             }
         }
 

--- a/Interfaces/IEwsHttpWebRequest.cs
+++ b/Interfaces/IEwsHttpWebRequest.cs
@@ -235,5 +235,13 @@ namespace Microsoft.Exchange.WebServices.Data
         {
             get; set;
         }
+
+        /// <summary>
+        /// Gets or sets if the request to the internet resource should allow high-speed NTLM-authenticated connection sharing
+        /// </summary>
+        bool UnsafeAuthenticatedConnectionSharing
+        {
+            get; set;
+        }
     }
 }


### PR DESCRIPTION
This enables EWS developers to set the flag UnsafeAuthenticatedConnectionSharing on HttpWebRequests created by exchange services in order to give them possibility to reuse connections while accessing on-premises Exchange servers with NTLM authentication. Http connections created with KeepAlive option and without UnsafeAuthenticatedConnectionSharing option lead to the socket leaks in the client application, leading to enormous number of half-open connections in TIME_WAIT state (one connection per request). This can even lead to exhaustion of the ephemeral ports on client machine. I see that you already have an issue on this: #85 . Some other guys in the internet also complain on it.