### PR TITLE
Fix #86: Add Serialization Constructors for Exceptions

### DIFF
--- a/Exceptions/AccountIsLockedException.cs
+++ b/Exceptions/AccountIsLockedException.cs
@@ -23,35 +23,60 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-namespace Microsoft.Exchange.WebServices.Data
+ namespace Microsoft.Exchange.WebServices.Data
 {
-    using System;
+	using System;
+	using System.Runtime.Serialization;
 
-    /// <summary>
-    /// Represents an error that occurs when the account that is being accessed is locked and requires user interaction to be unlocked.
-    /// </summary>
-    [Serializable]
-    public class AccountIsLockedException : ServiceRemoteException
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AccountIsLockedException"/> class.
-        /// </summary>
-        /// <param name="message">Error message text.</param>
-        /// <param name="accountUnlockUrl">URL for client to visit to unlock account.</param>
-        /// <param name="innerException">Inner exception.</param>
-        public AccountIsLockedException(string message, Uri accountUnlockUrl, Exception innerException)
-            : base(message, innerException)
-        {
-            this.AccountUnlockUrl = accountUnlockUrl;
-        }
+	/// <summary>
+	/// Represents an error that occurs when the account that is being accessed is locked and requires user interaction to be unlocked.
+	/// </summary>
+	[Serializable]
+	public class AccountIsLockedException : ServiceRemoteException
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AccountIsLockedException"/> class.
+		/// </summary>
+		/// <param name="message">Error message text.</param>
+		/// <param name="accountUnlockUrl">URL for client to visit to unlock account.</param>
+		/// <param name="innerException">Inner exception.</param>
+		public AccountIsLockedException(string message, Uri accountUnlockUrl, Exception innerException)
+			: base(message, innerException)
+		{
+			this.AccountUnlockUrl = accountUnlockUrl;
+		}
 
-        /// <summary>
-        /// Gets the URL of a web page where the user can navigate to unlock his or her account.
-        /// </summary>
-        public Uri AccountUnlockUrl
-        {
-            get;
-            private set;
-        }
-    }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.AccountIsLockedException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected AccountIsLockedException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.AccountUnlockUrl = (Uri)info.GetValue("AccountUnlockUrl", typeof(Uri));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "AccountIsLockedException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("AccountUnlockUrl", this.AccountUnlockUrl, typeof(Uri));
+		}
+
+		/// <summary>
+		/// Gets the URL of a web page where the user can navigate to unlock his or her account.
+		/// </summary>
+		public Uri AccountUnlockUrl
+		{
+			get;
+			private set;
+		}
+	}
 }

--- a/Exceptions/AutodiscoverLocalException.cs
+++ b/Exceptions/AutodiscoverLocalException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an exception that is thrown when the Autodiscover service could not be contacted.
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public AutodiscoverLocalException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.AutodiscoverLocalException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected AutodiscoverLocalException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+	}
 }

--- a/Exceptions/AutodiscoverRemoteException.cs
+++ b/Exceptions/AutodiscoverRemoteException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Autodiscover
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
     using Microsoft.Exchange.WebServices.Data;
 
     /// <summary>
@@ -36,7 +35,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
     [Serializable]
     public class AutodiscoverRemoteException : ServiceRemoteException
     {
-        private AutodiscoverError error;
+        private readonly AutodiscoverError error;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutodiscoverRemoteException"/> class.
@@ -72,13 +71,37 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
             : base(message, innerException)
         {
             this.error = error;
-        }
+		}
 
-        /// <summary>
-        /// Gets the error.
-        /// </summary>
-        /// <value>The error.</value>
-        public AutodiscoverError Error
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.AutodiscoverRemoteException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected AutodiscoverRemoteException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.error = (AutodiscoverError)info.GetValue("Error", typeof(AutodiscoverError));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "AutodiscoverRemoteException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("Error", this.error, typeof(Uri));
+		}
+
+		/// <summary>
+		/// Gets the error.
+		/// </summary>
+		/// <value>The error.</value>
+		public AutodiscoverError Error
         {
             get { return this.error; }
         }

--- a/Exceptions/AutodiscoverResponseException.cs
+++ b/Exceptions/AutodiscoverResponseException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Autodiscover
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
     using Microsoft.Exchange.WebServices.Data;
 
     /// <summary>
@@ -39,7 +38,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
         /// <summary>
         /// Error code when Autodiscover service operation failed remotely.
         /// </summary>
-        private AutodiscoverErrorCode errorCode;
+        private readonly AutodiscoverErrorCode errorCode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutodiscoverResponseException"/> class.
@@ -50,12 +49,36 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
             : base(message)
         {
             this.errorCode = errorCode;
-        }
+		}
 
-        /// <summary>
-        /// Gets the ErrorCode for the exception.
-        /// </summary>
-        public AutodiscoverErrorCode ErrorCode
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.AutodiscoverResponseException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected AutodiscoverResponseException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.errorCode = (AutodiscoverErrorCode)info.GetInt32("ErrorCode");
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "AutodiscoverResponseException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("ErrorCode", (int)this.errorCode);
+		}
+
+		/// <summary>
+		/// Gets the ErrorCode for the exception.
+		/// </summary>
+		public AutodiscoverErrorCode ErrorCode
         {
             get { return this.errorCode; }
         }

--- a/Exceptions/BatchServiceResponseException.cs
+++ b/Exceptions/BatchServiceResponseException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents a remote service exception that can have multiple service responses.
@@ -40,7 +39,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// The list of responses returned by the web method.
         /// </summary>
-        private ServiceResponseCollection<TResponse> responses;
+        private readonly ServiceResponseCollection<TResponse> responses;
 
         /// <summary>
         /// Initializes a new instance of MultiServiceResponseException.
@@ -78,12 +77,36 @@ namespace Microsoft.Exchange.WebServices.Data
                 "serviceResponses is null");
 
             this.responses = serviceResponses;
-        }
+		}
 
-        /// <summary>
-        /// Gets a list of responses returned by the web method.
-        /// </summary>
-        public ServiceResponseCollection<TResponse> ServiceResponses
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.BatchServiceResponseException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected BatchServiceResponseException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.responses = (ServiceResponseCollection<TResponse>)info.GetValue("Responses", typeof(ServiceResponseCollection<TResponse>));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "BatchServiceResponseException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("Responses", this.responses, typeof(ServiceResponseCollection<TResponse>));
+		}
+
+		/// <summary>
+		/// Gets a list of responses returned by the web method.
+		/// </summary>
+		public ServiceResponseCollection<TResponse> ServiceResponses
         {
             get { return this.responses; }
         }

--- a/Exceptions/CreateAttachmentException.cs
+++ b/Exceptions/CreateAttachmentException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a call to the CreateAttachment web method fails.
@@ -59,6 +58,16 @@ namespace Microsoft.Exchange.WebServices.Data
             Exception innerException)
             : base(serviceResponses, message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.CreateAttachmentException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private CreateAttachmentException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+	}
 }

--- a/Exceptions/DeleteAttachmentException.cs
+++ b/Exceptions/DeleteAttachmentException.cs
@@ -26,13 +26,12 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
 
-    /// <summary>
-    /// Represents an error that occurs when a call to the DeleteAttachment web method fails.
-    /// </summary>
-    [Serializable]
+	/// <summary>
+	/// Represents an error that occurs when a call to the DeleteAttachment web method fails.
+	/// </summary>
+	[Serializable]
     public sealed class DeleteAttachmentException : BatchServiceResponseException<DeleteAttachmentResponse>
     {
         /// <summary>
@@ -59,6 +58,16 @@ namespace Microsoft.Exchange.WebServices.Data
             Exception innerException)
             : base(serviceResponses, message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.DeleteAttachmentException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private DeleteAttachmentException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+	}
 }

--- a/Exceptions/DnsException.cs
+++ b/Exceptions/DnsException.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Exchange.WebServices.Dns
 {
     using System;
     using System.ComponentModel;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when performing a DNS operation.
@@ -41,6 +42,16 @@ namespace Microsoft.Exchange.WebServices.Dns
         internal DnsException(int errorCode)
             : base(errorCode)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.DnsException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected DnsException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+	}
 }

--- a/Exceptions/PropertyException.cs
+++ b/Exceptions/PropertyException.cs
@@ -23,11 +23,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when an operation on a property fails.
@@ -38,7 +38,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// The name of the property that is at the origin of the exception.
         /// </summary>
-        private string name;
+        private readonly string name;
 
         /// <summary>
         /// PropertyException constructor.
@@ -74,12 +74,36 @@ namespace Microsoft.Exchange.WebServices.Data
             : base(message, innerException)
         {
             this.name = name;
-        }
+		}
 
-        /// <summary>
-        /// Gets the name of the property that caused the exception.
-        /// </summary>
-        public string Name
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.PropertyException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected PropertyException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.name = info.GetString("PropertyName");
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "PropertyException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("PropertyName", this.name);
+		}
+
+		/// <summary>
+		/// Gets the name of the property that caused the exception.
+		/// </summary>
+		public string Name
         {
             get { return this.name; }
         }

--- a/Exceptions/ServerBusyException.cs
+++ b/Exceptions/ServerBusyException.cs
@@ -26,6 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
+	using System.Runtime.Serialization;
     
     /// <summary>
     /// Represents a server busy exception found in a service response.
@@ -34,7 +35,7 @@ namespace Microsoft.Exchange.WebServices.Data
     public class ServerBusyException : ServiceResponseException
     {
         private const string BackOffMillisecondsKey = @"BackOffMilliseconds";
-        private int backOffMilliseconds;
+        private readonly int backOffMilliseconds;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerBusyException"/> class.
@@ -47,13 +48,37 @@ namespace Microsoft.Exchange.WebServices.Data
             {
                 Int32.TryParse(response.ErrorDetails[ServerBusyException.BackOffMillisecondsKey], out this.backOffMilliseconds);
             }
-        }
-        
-        /// <summary>
-        /// Suggested number of milliseconds to wait before attempting a request again. If zero, 
-        /// there is no suggested backoff time.
-        /// </summary>
-        public int BackOffMilliseconds
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServerBusyException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServerBusyException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.backOffMilliseconds = info.GetInt32("BackOffMilliseconds");
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "ServerBusyException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("BackOffMilliseconds", this.backOffMilliseconds);
+		}
+
+		/// <summary>
+		/// Suggested number of milliseconds to wait before attempting a request again. If zero, 
+		/// there is no suggested backoff time.
+		/// </summary>
+		public int BackOffMilliseconds
         {
             get
             {

--- a/Exceptions/ServiceLocalException.cs
+++ b/Exceptions/ServiceLocalException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a service operation fails locally (e.g. validation error).
@@ -61,5 +60,14 @@ namespace Microsoft.Exchange.WebServices.Data
             : base(message, innerException)
         {
         }
-    }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceLocalException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceLocalException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceObjectPropertyException.cs
+++ b/Exceptions/ServiceObjectPropertyException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when an operation on a property fails.
@@ -38,7 +37,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// The definition of the property that is at the origin of the exception.
         /// </summary>
-        private PropertyDefinitionBase propertyDefinition;
+        private readonly PropertyDefinitionBase propertyDefinition;
 
         /// <summary>
         /// ServiceObjectPropertyException constructor.
@@ -74,12 +73,36 @@ namespace Microsoft.Exchange.WebServices.Data
             : base(message, propertyDefinition.GetPrintableName(), innerException)
         {
             this.propertyDefinition = propertyDefinition;
-        }
+		}
 
-        /// <summary>
-        /// Gets the definition of the property that caused the exception.
-        /// </summary>
-        public PropertyDefinitionBase PropertyDefinition
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceObjectPropertyException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceObjectPropertyException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.propertyDefinition = (PropertyDefinitionBase)info.GetValue("PropertyDefinition", typeof(PropertyDefinitionBase));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "ServiceObjectPropertyException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("PropertyDefinition", this.propertyDefinition, typeof(PropertyDefinitionBase));
+		}
+
+		/// <summary>
+		/// Gets the definition of the property that caused the exception.
+		/// </summary>
+		public PropertyDefinitionBase PropertyDefinition
         {
             get { return this.propertyDefinition; }
         }

--- a/Exceptions/ServiceRemoteException.cs
+++ b/Exceptions/ServiceRemoteException.cs
@@ -25,41 +25,50 @@
 
 namespace Microsoft.Exchange.WebServices.Data
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System;
+	using System.Runtime.Serialization;
 
-    /// <summary>
-    /// Represents an error that occurs when a service operation fails remotely.
-    /// </summary>
-    [Serializable]
-    public class ServiceRemoteException : Exception
-    {
-        /// <summary>
-        /// ServiceRemoteException Constructor.
-        /// </summary>
-        public ServiceRemoteException()
-            : base()
-        {
-        }
+	/// <summary>
+	/// Represents an error that occurs when a service operation fails remotely.
+	/// </summary>
+	[Serializable]
+	public class ServiceRemoteException : Exception
+	{
+		/// <summary>
+		/// ServiceRemoteException Constructor.
+		/// </summary>
+		public ServiceRemoteException()
+			: base()
+		{
+		}
 
-        /// <summary>
-        /// ServiceRemoteException Constructor.
-        /// </summary>
-        /// <param name="message">Error message text.</param>
-        public ServiceRemoteException(string message)
-            : base(message)
-        {
-        }
+		/// <summary>
+		/// ServiceRemoteException Constructor.
+		/// </summary>
+		/// <param name="message">Error message text.</param>
+		public ServiceRemoteException(string message)
+			: base(message)
+		{
+		}
 
-        /// <summary>
-        /// ServiceRemoteException Constructor.
-        /// </summary>
-        /// <param name="message">Error message text.</param>
-        /// <param name="innerException">Inner exception.</param>
-        public ServiceRemoteException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-    }
+		/// <summary>
+		/// ServiceRemoteException Constructor.
+		/// </summary>
+		/// <param name="message">Error message text.</param>
+		/// <param name="innerException">Inner exception.</param>
+		public ServiceRemoteException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceRemoteException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceRemoteException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceRequestException.cs
+++ b/Exceptions/ServiceRequestException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a service operation request fails (e.g. connection error).
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public ServiceRequestException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceRequestException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceRequestException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceResponseException.cs
+++ b/Exceptions/ServiceResponseException.cs
@@ -26,6 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents a remote service exception that has a single response.
@@ -43,7 +44,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// ServiceResponse when service operation failed remotely.
         /// </summary>
-        private ServiceResponse response;
+        private readonly ServiceResponse response;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceResponseException"/> class.
@@ -52,12 +53,36 @@ namespace Microsoft.Exchange.WebServices.Data
         internal ServiceResponseException(ServiceResponse response)
         {
             this.response = response;
-        }
+		}
 
-        /// <summary>
-        /// Gets the ServiceResponse for the exception.
-        /// </summary>
-        public ServiceResponse Response
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceResponseException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceResponseException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.response = (ServiceResponse)info.GetValue("Response", typeof(ServiceResponse));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "ServiceResponseException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("Response", this.response, typeof(ServiceResponse));
+		}
+
+		/// <summary>
+		/// Gets the ServiceResponse for the exception.
+		/// </summary>
+		public ServiceResponse Response
         {
             get { return this.response; }
         }

--- a/Exceptions/ServiceValidationException.cs
+++ b/Exceptions/ServiceValidationException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a validation check fails.
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public ServiceValidationException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceValidationException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private ServiceValidationException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceVersionException.cs
+++ b/Exceptions/ServiceVersionException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a request cannot be handled due to a service version mismatch.
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public ServiceVersionException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceVersionException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private ServiceVersionException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceXmlDeserializationException.cs
+++ b/Exceptions/ServiceXmlDeserializationException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when the XML for a response cannot be deserialized.
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public ServiceXmlDeserializationException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceXmlDeserializationException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private ServiceXmlDeserializationException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/ServiceXmlSerializationException.cs
+++ b/Exceptions/ServiceXmlSerializationException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when the XML for a request cannot be serialized.
@@ -60,6 +59,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public ServiceXmlSerializationException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.ServiceXmlSerializationException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected ServiceXmlSerializationException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/TimeZoneConversionException.cs
+++ b/Exceptions/TimeZoneConversionException.cs
@@ -26,8 +26,7 @@
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an error that occurs when a date and time cannot be converted from one time zone
@@ -61,6 +60,16 @@ namespace Microsoft.Exchange.WebServices.Data
         public TimeZoneConversionException(string message, Exception innerException)
             : base(message, innerException)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.TimeZoneConversionException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		protected TimeZoneConversionException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+	    {
+		}
+	}
 }

--- a/Exceptions/UpdateInboxRulesException.cs
+++ b/Exceptions/UpdateInboxRulesException.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.Exchange.WebServices.Data;
+	using System.Runtime.Serialization;
 
     /// <summary>
     /// Represents an exception thrown when an error occurs as a result of calling 
@@ -39,12 +39,12 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// ServiceResponse when service operation failed remotely.
         /// </summary>
-        private ServiceResponse serviceResponse;
+        private readonly ServiceResponse serviceResponse;
 
         /// <summary>
         /// Rule operation error collection.
         /// </summary>
-        private RuleOperationErrorCollection errors;
+        private readonly RuleOperationErrorCollection errors;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateInboxRulesException"/> class.
@@ -60,12 +60,38 @@ namespace Microsoft.Exchange.WebServices.Data
             {
                 error.SetOperationByIndex(ruleOperations);
             }
-        }
+		}
 
-        /// <summary>
-        /// Gets the ServiceResponse for the exception.
-        /// </summary>
-        public ServiceResponse ServiceResponse
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Microsoft.Exchange.WebServices.Data.UpdateInboxRulesException"/> class with serialized data.
+		/// </summary>
+		/// <param name="info">The object that holds the serialized object data.</param>
+		/// <param name="context">The contextual information about the source or destination.</param>
+		private UpdateInboxRulesException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			this.serviceResponse = (ServiceResponse)info.GetValue("ServiceResponse", typeof(ServiceResponse));
+			this.errors = (RuleOperationErrorCollection)info.GetValue("Errors", typeof(RuleOperationErrorCollection));
+		}
+
+		/// <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the parameter name and additional exception information.</summary>
+		/// <param name="info">The object that holds the serialized object data. </param>
+		/// <param name="context">The contextual information about the source or destination. </param>
+		/// <exception cref="T:System.ArgumentNullException">The <paramref name="info" /> object is a null reference (Nothing in Visual Basic). </exception>
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			EwsUtilities.Assert(info != null, "UpdateInboxRulesException.GetObjectData", "info is null");
+
+			base.GetObjectData(info, context);
+
+			info.AddValue("Errors", this.errors, typeof(RuleOperationErrorCollection));
+			info.AddValue("ServiceResponse", this.serviceResponse, typeof(ServiceResponse));
+		}
+
+		/// <summary>
+		/// Gets the ServiceResponse for the exception.
+		/// </summary>
+		public ServiceResponse ServiceResponse
         {
             get { return this.serviceResponse; }
         }


### PR DESCRIPTION
Fix for issue #86. Added constructors and methods required
for serialization for exception classes. This is required to get
actual exceptions on client side of ditributed application.
