### PR TITLE
Abort request if IOException occurs otherwise Async responses seems t…

### DIFF
--- a/Core/Requests/ServiceRequestBase.cs
+++ b/Core/Requests/ServiceRequestBase.cs
@@ -685,9 +685,10 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <returns>An IEwsHttpWebRequest instance</returns>
         protected IEwsHttpWebRequest BuildEwsHttpWebRequest()
         {
+            IEwsHttpWebRequest request = null;
             try
             {
-                IEwsHttpWebRequest request = this.Service.PrepareHttpWebRequest(this.GetXmlElementName());
+                request = this.Service.PrepareHttpWebRequest(this.GetXmlElementName());
 
                 this.Service.TraceHttpRequestHeaders(TraceFlags.EwsRequestHttpHeaders, request);
 
@@ -723,6 +724,10 @@ namespace Microsoft.Exchange.WebServices.Data
             }
             catch (IOException e)
             {
+                if (request != null)
+                {
+                    request.Abort();
+                }
                 // Wrap exception.
                 throw new ServiceRequestException(string.Format(Strings.ServiceRequestFailed, e.Message), e);
             }


### PR DESCRIPTION
Abort request if IOException occurs otherwise Async responses seems to be hanging after two failed attempemts
Releated to Issue #113 