### PR TITLE
Add public interface to search for folders in multiple folders using the same filter

### DIFF
--- a/Core/ExchangeService.cs
+++ b/Core/ExchangeService.cs
@@ -211,6 +211,28 @@ namespace Microsoft.Exchange.WebServices.Data
 
             return responses[0].Results;
         }
+        
+        /// <summary>
+        /// Obtains a list of folders by searching the sub-folders of each of the specified folders.
+        /// </summary>
+        /// <param name="parentFolderIds">The Ids of the folders in which to search for folders.</param>
+        /// <param name="searchFilter">The search filter. Available search filter classes
+        /// include SearchFilter.IsEqualTo, SearchFilter.ContainsSubstring and 
+        /// SearchFilter.SearchFilterCollection</param>
+        /// <param name="view">The view controlling the number of folders returned.</param>
+        /// <returns>An object representing the results of the search operation.</returns>
+        public ServiceResponseCollection<FindFolderResponse> FindFolders(IEnumerable<FolderId> parentFolderIds, SearchFilter searchFilter, FolderView view)
+        {
+            EwsUtilities.ValidateParam(parentFolderIds, "parentFolderIds");
+            EwsUtilities.ValidateParam(view, "view");
+            EwsUtilities.ValidateParamAllowNull(searchFilter, "searchFilter");
+
+            return this.InternalFindFolders(
+                parentFolderIds,
+                searchFilter,
+                view,
+                ServiceErrorHandling.ReturnErrors);
+        }
 
         /// <summary>
         /// Obtains a list of folders by searching the sub-folders of the specified folder.

--- a/Core/Responses/FindFolderResponse.cs
+++ b/Core/Responses/FindFolderResponse.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Exchange.WebServices.Data
     /// <summary>
     /// Represents the response to a folder search operation.
     /// </summary>
-    internal sealed class FindFolderResponse : ServiceResponse
+    public sealed class FindFolderResponse : ServiceResponse
     {
         private FindFoldersResults results = new FindFoldersResults();
         private PropertySet propertySet;


### PR DESCRIPTION
This can speed things up significantly when having to search for lots of folders with the same name from multiple mailboxes (requires delegation rather than impersonation though), one use case is when setting up subscriptions from a lot of mailboxes.

This also needs to make FindFolderResponse public so the responses can be represented.