### PR TITLE
Add public constructor to StreamingSubscription for continuing an existing subscription

### DIFF
--- a/Notifications/StreamingSubscription.cs
+++ b/Notifications/StreamingSubscription.cs
@@ -42,6 +42,17 @@ namespace Microsoft.Exchange.WebServices.Data
         }
 
         /// <summary>
+        /// Initializes a new instance with the specified subscription id, for continuing an existing subscription.
+        /// </summary>
+        /// <param name="service">The service.</param>
+        /// <param name="subscriptionId">The id of a previously created streaming subscription.</param>
+        public StreamingSubscription(ExchangeService service, string subscriptionId)
+            : base(service)
+        {
+            this.Id = subscriptionId;
+        }
+
+        /// <summary>
         /// Unsubscribes from the streaming subscription.
         /// </summary>
         public void Unsubscribe()


### PR DESCRIPTION
The use case is if you have a service that is listening for changes to potentially tens of thousands of mailboxes then it can take a long time to create all the subscriptions (several hours!). So caching those subscription ids can substantially speed up the restart of the service enormously (at least as long as they are still valid). However to do that we need to be able to create subscription objects representing those existing subscriptions.