### PR TITLE
Add SetUserPhoto capability

### DIFF
--- a/Core/ExchangeService.cs
+++ b/Core/ExchangeService.cs
@@ -23,6 +23,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+using System.Security.Cryptography;
+
 namespace Microsoft.Exchange.WebServices.Data
 {
     using System;
@@ -1741,6 +1743,25 @@ namespace Microsoft.Exchange.WebServices.Data
             request.EmailAddress = emailAddress;
             request.UserPhotoSize = userPhotoSize;
             request.EntityTag = entityTag;
+
+            return request.Execute().Results;
+        }
+
+        /// <summary>
+        /// Set a user's photo.
+        /// </summary>
+        /// <param name="emailAddress">The user's email address</param>
+        /// <param name="photo">The photo to set</param>
+        /// <returns>A result object</returns>
+        public SetUserPhotoResults SetUserPhoto(string emailAddress, byte[] photo)
+        {
+            EwsUtilities.ValidateParam(emailAddress, "emailAddress");
+            EwsUtilities.ValidateParam(photo, "photo");
+            
+            SetUserPhotoRequest request = new SetUserPhotoRequest(this);
+
+            request.EmailAddress = emailAddress;
+            request.Photo = photo;
 
             return request.Execute().Results;
         }

--- a/Core/Requests/SetUserPhotoRequest.cs
+++ b/Core/Requests/SetUserPhotoRequest.cs
@@ -1,0 +1,180 @@
+/*
+ * Exchange Web Services Managed API
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+using System.Drawing.Imaging;
+
+namespace Microsoft.Exchange.WebServices.Data
+{
+    using System;
+    using System.Net;
+    using Microsoft.Exchange.WebServices.Data;
+
+    /// <summary>
+    /// Represents a request of a get user photo operation
+    /// </summary>
+    internal sealed class SetUserPhotoRequest : SimpleServiceRequestBase
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="service">Exchange web service</param>
+        internal SetUserPhotoRequest(ExchangeService service)
+            : base(service)
+        {
+        }
+
+        /// <summary>
+        /// email address accessor
+        /// </summary>
+        internal string EmailAddress { get; set; }
+
+        internal byte[] Photo { get; set; }
+
+        /// <summary>
+        /// Validate request.
+        /// </summary>
+        internal override void Validate()
+        {
+            if (string.IsNullOrEmpty(this.EmailAddress))
+            {
+                throw new ServiceLocalException(Strings.InvalidEmailAddress);
+            }
+
+            if (this.Photo == null || this.Photo.Length <= 0)
+            {
+                throw new ServiceLocalException(Strings.UserPhotoNotSpecified);
+            }
+
+            base.Validate();
+        }
+
+        /// <summary>
+        /// Writes XML attributes.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        internal override void WriteAttributesToXml(EwsServiceXmlWriter writer)
+        {
+            base.WriteAttributesToXml(writer);
+        }
+
+        /// <summary>
+        /// Writes XML elements.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        internal override void WriteElementsToXml(EwsServiceXmlWriter writer)
+        {
+            // Emit the EmailAddress element
+            writer.WriteStartElement(XmlNamespace.Messages, XmlElementNames.Email);
+            writer.WriteValue(this.EmailAddress, XmlElementNames.Email);
+            writer.WriteEndElement();
+
+            string encodedPhoto = Convert.ToBase64String(this.Photo);
+
+            writer.WriteStartElement(XmlNamespace.Messages, XmlElementNames.Content);
+            writer.WriteValue(encodedPhoto, XmlElementNames.Content);
+            writer.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Adds header values to the request
+        /// </summary>
+        /// <param name="webHeaderCollection">The collection of headers to add to</param>
+        internal override void AddHeaders(WebHeaderCollection webHeaderCollection)
+        {
+        }
+
+        /// <summary>
+        /// Parses the response.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        /// <param name="responseHeaders">The HTTP response headers</param>
+        /// <returns>Response object.</returns>
+        internal override object ParseResponse(EwsServiceXmlReader reader, WebHeaderCollection responseHeaders)
+        {
+            SetUserPhotoResponse response = new SetUserPhotoResponse();
+            response.LoadFromXml(reader, XmlElementNames.SetUserPhotoResponse);
+            response.ReadHeader(responseHeaders);
+            return response;
+        }
+
+        /// <summary>
+        /// Gets the name of the XML element.
+        /// </summary>
+        /// <returns>XML element name.</returns>
+        internal override string GetXmlElementName()
+        {
+            return XmlElementNames.SetUserPhoto;
+        }
+
+        /// <summary>
+        /// Gets the name of the response XML element.
+        /// </summary>
+        /// <returns>XML element name.</returns>
+        internal override string GetResponseXmlElementName()
+        {
+            return XmlElementNames.SetUserPhotoResponse;
+        }
+
+        /// <summary>
+        /// Gets the request version.
+        /// </summary>
+        /// <returns>Earliest Exchange version in which this request is supported.</returns>
+        internal override ExchangeVersion GetMinimumRequiredServerVersion()
+        {
+            return ExchangeVersion.Exchange2016;
+        }
+
+        /// <summary>
+        /// Executes this request.
+        /// </summary>
+        /// <returns>Service response.</returns>
+        internal SetUserPhotoResponse Execute()
+        {
+            return SetUserPhotoRequest.SetResultOrDefault(this.InternalExecute);
+        }
+
+                /// <summary>
+        /// Ends executing this async request.
+        /// </summary>
+        /// <param name="asyncResult">The async result</param>
+        /// <returns>Service response collection.</returns>
+        internal SetUserPhotoResponse EndExecute(IAsyncResult asyncResult)
+        {
+            return SetUserPhotoRequest.SetResultOrDefault(() => this.EndInternalExecute(asyncResult));
+        }
+
+        private static SetUserPhotoResponse SetResultOrDefault(Func<object> serviceResponseFactory)
+        {
+            try
+            {
+                return (SetUserPhotoResponse)serviceResponseFactory();
+            }
+            catch (ServiceRequestException ex)
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/Core/Responses/SetUserPhotoResponse.cs
+++ b/Core/Responses/SetUserPhotoResponse.cs
@@ -1,0 +1,70 @@
+/*
+ * Exchange Web Services Managed API
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Microsoft.Exchange.WebServices.Data
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Net;
+    using System.Xml;
+
+    /// <summary>
+    /// Represents the response to GetUserPhoto operation.
+    /// </summary>
+    internal sealed class SetUserPhotoResponse : ServiceResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetUserPhotoResponse"/> class.
+        /// </summary>
+        internal SetUserPhotoResponse()
+        {
+            this.Results = new SetUserPhotoResults();
+        }
+
+        /// <summary>
+        /// Gets GetUserPhoto results.
+        /// </summary>
+        /// <returns>GetUserPhoto results.</returns>
+        internal SetUserPhotoResults Results { get; private set; }
+
+        /// <summary>
+        /// Read Photo results from XML.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        internal override void ReadElementsFromXml(EwsServiceXmlReader reader)
+        {
+        }
+
+        /// <summary>
+        /// Read Photo response headers
+        /// </summary>
+        /// <param name="responseHeaders">The response header.</param>
+        internal override void ReadHeader(WebHeaderCollection responseHeaders)
+        {
+        }
+    }
+}

--- a/Core/Responses/SetUserPhotoResults.cs
+++ b/Core/Responses/SetUserPhotoResults.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Exchange Web Services Managed API
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Microsoft.Exchange.WebServices.Data
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Drawing;
+    using System.IO;
+    using Microsoft.Exchange.WebServices.Data.Enumerations;
+
+    /// <summary>
+    /// Represents the results of a GetUserPhoto operation.
+    /// </summary>
+    public sealed class SetUserPhotoResults
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="Microsoft.Exchange.WebServices.Data.GetUserPhotoResults"/> class.
+        /// </summary>
+        internal SetUserPhotoResults()
+        {
+        }
+        
+    }
+}

--- a/Core/XmlElementNames.cs
+++ b/Core/XmlElementNames.cs
@@ -409,6 +409,7 @@ namespace Microsoft.Exchange.WebServices.Data
         public const string CalendarView = "CalendarView";
         public const string PostedTime = "PostedTime";
         public const string PostItem = "PostItem";
+        public const string RequestVersion = "RequestVersion";
         public const string RequestServerVersion = "RequestServerVersion";
         public const string PostReplyItem = "PostReplyItem";
         public const string CreateAssociated = "CreateAssociated";
@@ -1311,6 +1312,12 @@ namespace Microsoft.Exchange.WebServices.Data
         public const string GetUserPhoto = "GetUserPhoto";
         public const string GetUserPhotoResponse = "GetUserPhotoResponse";
         public const string GetUserPhotoResponseMessage = "GetUserPhotoResponseMessage";
+
+        // SetUserPhoto
+        public const string SetUserPhoto = "SetUserPhoto";
+        public const string SetUserPhotoResponse = "SetUserPhotoResponse";
+        public const string SetUserPhotoResponseMessage = "SetUserPhotoResponseMessage";
+
 
         // GetAttachment
         public const string GetAttachment = "GetAttachment";

--- a/Microsoft.Exchange.WebServices.Data.csproj
+++ b/Microsoft.Exchange.WebServices.Data.csproj
@@ -98,10 +98,13 @@
     <Compile Include="ComplexProperties\ReferenceAttachment.cs" />
     <Compile Include="Core\Requests\GetOMEConfigurationRequest.cs" />
     <Compile Include="Core\Requests\GetPeopleInsightsRequest.cs" />
+    <Compile Include="Core\Requests\SetUserPhotoRequest.cs" />
     <Compile Include="Core\Requests\GetUserPhotoRequest.cs" />
     <Compile Include="Core\Requests\SetOMEConfigurationRequest.cs" />
+    <Compile Include="Core\Responses\SetUserPhotoResults.cs" />
     <Compile Include="Core\Responses\GetOMEConfigurationResponse.cs" />
     <Compile Include="Core\Responses\GetPeopleInsightsResponse.cs" />
+    <Compile Include="Core\Responses\SetUserPhotoResponse.cs" />
     <Compile Include="Core\Responses\GetUserPhotoResponse.cs" />
     <Compile Include="Core\Responses\SetOMEConfigurationResponse.cs" />
     <Compile Include="Core\Responses\RegisterConsentResponse.cs" />

--- a/Strings.cs
+++ b/Strings.cs
@@ -224,5 +224,7 @@ namespace Microsoft.Exchange.WebServices
         internal static string XsDurationCouldNotBeParsed = "The specified xsDuration argument couldn't be parsed.";
         internal static string UnknownTimeZonePeriodTransitionType = "Unknown time zone transition type: {0}";
         internal static string UserPhotoSizeNotSpecified = "The UserPhotoSize must be not be null or empty.";
+        internal static string UserPhotoNotSpecified = "The photo must be not be null or empty.";
+
     }
 }


### PR DESCRIPTION
Exchange 2016 added support for setting a users photo.  This PR adds this missing capability. 