### PR TITLE
Proxy should be copied from template service

### DIFF
--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -549,6 +549,7 @@ namespace Microsoft.Exchange.WebServices.Data
             this.timeZone = service.timeZone;
             this.httpHeaders = service.httpHeaders;
             this.ewsHttpWebRequestFactory = service.ewsHttpWebRequestFactory;
+            this.webProxy = service.webProxy;
         }
 
         /// <summary>


### PR DESCRIPTION
Discovery service ignores proxy configuration passed via EwsService.WebProxy.
Copying it in ExchangeServiceBase fix this issue.