### PR TITLE
Make XmlDtdException serializable

### DIFF
--- a/Security/XmlDtdException.cs
+++ b/Security/XmlDtdException.cs
@@ -25,6 +25,7 @@
 
 namespace Microsoft.Exchange.WebServices.Data
 {
+    using System.Runtime.Serialization;
     using System.Xml;
 
     /// <summary>
@@ -38,6 +39,23 @@ namespace Microsoft.Exchange.WebServices.Data
         public override string Message
         {
             get { return "For security reasons DTD is prohibited in this XML document."; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlDtdException"/> class.
+        /// </summary>
+        public XmlDtdException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlDtdException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected XmlDtdException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }


### PR DESCRIPTION
This one was missed in the fix for #86 (PR #100)