### PR TITLE
Make ServiceResponse.ThrowIfNecessary public

### DIFF
--- a/Core/Responses/ServiceResponse.cs
+++ b/Core/Responses/ServiceResponse.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// Throws a ServiceResponseException if this response has its Result property set to Error.
         /// </summary>
-        internal void ThrowIfNecessary()
+        public void ThrowIfNecessary()
         {
             this.InternalThrowIfNecessary();
         }


### PR DESCRIPTION
This is useful for uniform error handling for consumers, i.e. reusing errorhandling code for "single" and "multiple/batch" requests.