### PR TITLE
InstallApp procedure fails

### DIFF
--- a/Core/Requests/InstallAppRequest.cs
+++ b/Core/Requests/InstallAppRequest.cs
@@ -71,8 +71,6 @@ namespace Microsoft.Exchange.WebServices.Data
 
             writer.WriteBase64ElementValue(manifestStream);
 
-            writer.WriteEndElement();
-
             if (!string.IsNullOrEmpty(this.marketplaceAssetId))
             {
                 writer.WriteElementValue(XmlNamespace.Messages, XmlElementNames.MarketplaceAssetId, this.marketplaceAssetId);


### PR DESCRIPTION

InstallApp procedure doesn't work, because End Element is being written twice, which results in exception below:

```
Exception: System.InvalidOperationException: Token EndElement in state EndRootElement would result in an invalid XML document. Make sure that the ConformanceLevel setting is set to ConformanceLevel.Fragment or ConformanceLevel.Auto if you want to write an XML fragment.
at System.Xml.XmlWellFormedWriter.ThrowInvalidStateTransition(Token token, State currentState)
at System.Xml.XmlWellFormedWriter.AdvanceState(Token token)
at System.Xml.XmlWellFormedWriter.WriteEndElement()
at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.WriteToXml(EwsServiceXmlWriter writer)
at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.EmitRequest(IEwsHttpWebRequest request)
at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.BuildEwsHttpWebRequest()
at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.ValidateAndEmitRequest(IEwsHttpWebRequest& request)
at Microsoft.Exchange.WebServices.Data.InstallAppRequest.Execute()
at Microsoft.Exchange.WebServices.Data.ExchangeService.InternalInstallApp(Stream manifestStream, String marketplaceAssetId, String marketplaceContentMarket, Boolean sendWelcomeEmail)
at Microsoft.Exchange.WebServices.Data.ExchangeService.InstallApp(Stream manifestStream)
```
