### PR TITLE
InstallAppResponse throws StackOverflowException

### DIFF
--- a/Core/Responses/InstallAppResponse.cs
+++ b/Core/Responses/InstallAppResponse.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// </summary>
         public bool? WasFirstInstall
         {
-            get { return this.WasFirstInstall; }
+            get { return this.wasFirstInstall; }
         }
     }
 }


### PR DESCRIPTION
InstallAppResponse throws `StackOverflowException` while trying to access `WasFirstInstall` property