### PR TITLE
Added folderIds for SubscribeToStreamingNotifications

### DIFF
--- a/Core/ExchangeService.cs
+++ b/Core/ExchangeService.cs
@@ -2849,7 +2849,9 @@ namespace Microsoft.Exchange.WebServices.Data
 
             EwsUtilities.ValidateParamCollection(folderIds, "folderIds");
 
-            return this.BuildSubscribeToStreamingNotificationsRequest(folderIds, eventTypes).Execute()[0].Subscription;
+            StreamingSubscription StreamingSub = this.BuildSubscribeToStreamingNotificationsRequest(folderIds, eventTypes).Execute()[0].Subscription;
+            StreamingSub.folderIds = folderIds;
+            return StreamingSub;
         }
 
         /// <summary>

--- a/Notifications/StreamingSubscription.cs
+++ b/Notifications/StreamingSubscription.cs
@@ -101,5 +101,10 @@ namespace Microsoft.Exchange.WebServices.Data
                 return false;
             }
         }
+
+        /// <summary>
+        /// List of the folderIds in the subscription.
+        /// </summary>
+        public System.Collections.Generic.IEnumerable<FolderId> folderIds;
     }
 }


### PR DESCRIPTION
I develop app for monitoring Exchange by using SubscribeToStreamingNotifications and in  StreamingSubscription class value of folderIds was lacked.
In order not to modify a lot of code, I added support for this parameter in the easiest way as is possible.
Such functionality will certainly be useful for others as well.