### PR TITLE
Add missing enum value for phoneNumberKey

### DIFF
--- a/Enumerations/PhoneNumberKey.cs
+++ b/Enumerations/PhoneNumberKey.cs
@@ -25,10 +25,6 @@
 
 namespace Microsoft.Exchange.WebServices.Data
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
     /// <summary>
     /// Defines phone number entries for a contact.
     /// </summary>
@@ -127,6 +123,26 @@ namespace Microsoft.Exchange.WebServices.Data
         /// <summary>
         /// The TTY/TTD phone number.
         /// </summary>
-        TtyTddPhone
+        TtyTddPhone,
+
+        /// <summary>
+        /// Business mobile number.
+        /// </summary>
+        BusinessMobile,
+
+        /// <summary>
+        /// IP Phone number.
+        /// </summary>
+        IPPhone,
+
+        /// <summary>
+        /// Mms number.
+        /// </summary>
+        Mms,
+
+        /// <summary>
+        /// Msn number.
+        /// </summary>
+        Msn
     }
 }


### PR DESCRIPTION
Bringing the enum up to date with the EWS schema since this is causing problems for some users of the managed API.