### PR TITLE
Expose HttpWebRequest.UnsafeAuthenticatedConnectionSharing

### DIFF
--- a/Core/EwsHttpWebRequest.cs
+++ b/Core/EwsHttpWebRequest.cs
@@ -285,6 +285,15 @@ namespace Microsoft.Exchange.WebServices.Data
         }
 
         /// <summary>
+        /// Gets or sets a value that indicates whether to allow high-speed NTLM-authenticated connection sharing.
+        /// </summary>
+        public bool UnsafeAuthenticatedConnectionSharing
+        {
+            get { return this.request.UnsafeAuthenticatedConnectionSharing; }
+            set { this.request.UnsafeAuthenticatedConnectionSharing = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the name of the connection group for the request. 
         /// </summary>
         public string ConnectionGroupName

--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Exchange.WebServices.Data
         private string userAgent = ExchangeService.defaultUserAgent;
         private bool acceptGzipEncoding = true;
         private bool keepAlive = true;
+        private bool unsafeAuthenticatedConnectionSharing = false;
         private string connectionGroupName;
         private string clientRequestId;
         private bool returnClientRequestId;
@@ -820,6 +821,22 @@ namespace Microsoft.Exchange.WebServices.Data
             set
             {
                 this.keepAlive = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether to allow high-speed NTLM-authenticated connection sharing.
+        /// </summary>
+        public bool UnsafeAuthenticatedConnectionSharing
+        {
+            get
+            {
+                return this.unsafeAuthenticatedConnectionSharing;
+            }
+
+            set
+            {
+                this.unsafeAuthenticatedConnectionSharing = value;
             }
         }
 

--- a/Interfaces/IEwsHttpWebRequest.cs
+++ b/Interfaces/IEwsHttpWebRequest.cs
@@ -229,6 +229,14 @@ namespace Microsoft.Exchange.WebServices.Data
         }
 
         /// <summary>
+        /// Gets or sets a value that indicates whether to allow high-speed NTLM-authenticated connection sharing.
+        /// </summary>
+        bool UnsafeAuthenticatedConnectionSharing
+        {
+            get; set;
+        }
+
+        /// <summary>
         /// Gets or sets the name of the connection group for the request. 
         /// </summary>
         string ConnectionGroupName


### PR DESCRIPTION
By default a new connection is used per authenticated request. Exposing
UnsafeAuthenticatedConnectionSharing allows callers aware of the
security considerations to opt in to connection reuse.