### PR TITLE
Fixed several issues with the creation of the TimeZoneDefinition object

### DIFF
--- a/ComplexProperties/TimeZones/AbsoluteDateTransition.cs
+++ b/ComplexProperties/TimeZones/AbsoluteDateTransition.cs
@@ -85,10 +85,14 @@ namespace Microsoft.Exchange.WebServices.Data
         {
             base.WriteElementsToXml(writer);
 
+            // Write the DateTime element as a datetime value formatted with no time zone conversions.
+            // We must not pass the dateTime value to WriteElementValue as a DateTime value, because
+            // WriteElementValue would convert the DateTime value to UTC using the time zone
+            // on the ExchangeService object. No time zone conversions should be done on transition objects.
             writer.WriteElementValue(
                 XmlNamespace.Types,
                 XmlElementNames.DateTime,
-                this.dateTime);
+                dateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/ComplexProperties/TimeZones/TimeZoneInfoExtensionMethods.cs
+++ b/ComplexProperties/TimeZones/TimeZoneInfoExtensionMethods.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.Exchange.WebServices.Data
+{
+    /// <summary>
+    /// Utility class for declaring time zone related extension methods.
+    /// </summary>
+    public static class TimeZoneInfoExtensionMethods
+    {
+        /// <summary>
+        /// Extension method to return the internal BaseUtcOffsetDelta property value from an AdjustmentRule.
+        /// </summary>
+        /// <param name="adjustmentRule">The adjustement rule whose BaseUtcOffsetDelta value should be returned.</param>
+        /// <returns>A TimeSpan value that reprensents the AdjustmentRule's BaseUtcOffsetDelta value.</returns>
+        public static TimeSpan GetBaseUtcOffsetDelta(this TimeZoneInfo.AdjustmentRule adjustmentRule)
+        {
+            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            PropertyInfo property = typeof(TimeZoneInfo.AdjustmentRule).GetProperty("BaseUtcOffsetDelta", bindFlags);
+            return (TimeSpan)property.GetValue(adjustmentRule, null);
+        }
+
+        /// <summary>
+        /// Extension method to determine if two TransitionTime values reference the same day.
+        /// </summary>
+        /// <param name="thisTransitionTime">The first TransitionTime to compare.</param>
+        /// <param name="otherTransitionTime">The second TransitionTime to compare.</param>
+        /// <returns>True if both TransitionTime objects reference the same day, otherwise false.</returns>
+        public static bool HasSameDate(this TimeZoneInfo.TransitionTime thisTransitionTime, TimeZoneInfo.TransitionTime otherTransitionTime)
+        {
+            if (thisTransitionTime.IsFixedDateRule && otherTransitionTime.IsFixedDateRule)
+            {
+                return (thisTransitionTime.Month == otherTransitionTime.Month)
+                    && (thisTransitionTime.Day == otherTransitionTime.Day);
+            }
+            else if (!thisTransitionTime.IsFixedDateRule && !otherTransitionTime.IsFixedDateRule)
+            {
+                return (thisTransitionTime.Month == otherTransitionTime.Month)
+                    && (thisTransitionTime.Week == otherTransitionTime.Week)
+                    && (thisTransitionTime.DayOfWeek == otherTransitionTime.DayOfWeek);
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Core/Requests/SetUserPhotoRequest.cs
+++ b/Core/Requests/SetUserPhotoRequest.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Exchange.WebServices.Data
             {
                 return (SetUserPhotoResponse)serviceResponseFactory();
             }
-            catch (ServiceRequestException ex)
+            catch (ServiceRequestException)
             {
                 throw;
             }

--- a/EwsManagedApiTest/EwsManagedApiTest.csproj
+++ b/EwsManagedApiTest/EwsManagedApiTest.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{68BFE270-3677-422A-9394-C0D8FECDC28B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EwsManagedApiTest</RootNamespace>
+    <AssemblyName>EwsManagedApiTest</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="TimeZoneTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Exchange.WebServices.Data.csproj">
+      <Project>{f059972f-0561-4203-abb8-3abb41ccbe22}</Project>
+      <Name>Microsoft.Exchange.WebServices.Data</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/EwsManagedApiTest/ExtensionMethods.cs
+++ b/EwsManagedApiTest/ExtensionMethods.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Exchange.WebServices.Data;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace EwsManagedApiTest
+{
+    /// <summary>
+    /// A class for extension methods to assist.
+    /// </summary>
+    static class ExtensionMethods
+    {
+        /// <summary>
+        /// Returns the collection of TimeZoneTransitions that are contained within the TimeZoneDefinition object.
+        /// Uses reflection to access the private field member.
+        /// </summary>
+        /// <param name="timeZoneDefinition">The TimeZoneDefinition object whose transitions are to be returned.</param>
+        /// <returns>The collection of TimeZoneTransition objects.</returns>
+        public static List<TimeZoneTransition> GetTransitions(this TimeZoneDefinition timeZoneDefinition)
+        {
+            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            FieldInfo field = typeof(TimeZoneDefinition).GetField("transitions", bindFlags);
+            return field.GetValue(timeZoneDefinition) as List<TimeZoneTransition>;
+        }
+    }
+}

--- a/EwsManagedApiTest/Properties/AssemblyInfo.cs
+++ b/EwsManagedApiTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EwsManagedApiTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EwsManagedApiTest")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("68bfe270-3677-422a-9394-c0d8fecdc28b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EwsManagedApiTest/TimeZoneTest.cs
+++ b/EwsManagedApiTest/TimeZoneTest.cs
@@ -1,0 +1,402 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Exchange.WebServices.Data;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace EwsManagedApiTest
+{
+    /// <summary>
+    /// A collection unit tests for testing EWS's Time Zone classes.
+    /// </summary>
+    [TestClass]
+    public class TimeZoneTest
+    {
+        /// <summary>
+        /// An enumeration used to classify a time zone period as either a standard period or a daylight period.
+        /// </summary>
+        public enum TimeZonePeriodType
+        {
+            Standard,
+            Daylight
+        }
+
+        /// <summary>
+        /// Verifies that the TimeZoneDefinition contains the period identified by the provided ID string, and that the period
+        /// matches the values in the specified TimeZoneInfo object and optionally a specific AdjustmentRule.
+        /// </summary>
+        /// <param name="tzd">The TimeZoneDefinion object containing the period to validate.</param>
+        /// <param name="periodId">The ID of the period to validate.</param>
+        /// <param name="tzInfo">The TimeZoneInfo object used to construct the TimeZoneDefinition object.</param>
+        /// <param name="adjustmentRule">An optional adjustment rule that applies to the period being validated.</param>
+        /// <returns>A enum value indicating whether the period was a Daylight period or a Standard period.</returns>
+        private TimeZonePeriodType ValidateTimeZonePeriod(TimeZoneDefinition tzd, String periodId, TimeZoneInfo tzInfo, TimeZoneInfo.AdjustmentRule adjustmentRule)
+        {
+            TimeZonePeriod period;
+
+            Assert.IsTrue(tzd.Periods.TryGetValue(periodId, out period), "The period was not found in the Time Zone Definition.");
+
+            TimeSpan expectedBias;
+            TimeZonePeriodType periodType;
+
+            if (period.IsStandardPeriod)
+            {
+                expectedBias = tzInfo.BaseUtcOffset;
+                if (adjustmentRule != null)
+                {
+                    expectedBias += adjustmentRule.GetBaseUtcOffsetDelta();
+                }
+
+                periodType = TimeZonePeriodType.Standard;
+            }
+            else
+            {
+                Assert.IsNotNull(adjustmentRule, "A daylight period was encountered without a matching adjustment rule.");
+
+                expectedBias = tzInfo.BaseUtcOffset + adjustmentRule.GetBaseUtcOffsetDelta() + adjustmentRule.DaylightDelta;
+
+                periodType = TimeZonePeriodType.Daylight;
+            }
+
+            Assert.AreEqual(expectedBias, TimeSpan.Zero - period.Bias, "A period bias was not correct.");
+            return periodType;
+        }
+
+        /// <summary>
+        /// Verifies that the TimeZoneDefinition contains the transition group identified by the provided ID string, 
+        /// and that the transition group represents a year with no DST period and that the group
+        /// matches the values in the specified TimeZoneInfo object and optionally a specific AdjustmentRule.
+        /// </summary>
+        /// <param name="tzd">The TimeZoneDefinion object containing the transition group to validate.</param>
+        /// <param name="groupId">The ID of the transition group to validate.</param>
+        /// <param name="tzInfo">The TimeZoneInfo object used to construct the TimeZoneDefinition object.</param>
+        /// <param name="adjustmentRule">An optional adjustment rule that applies to the transition group being validated.</param>
+        private void ValidateStandardTransitionGroup(TimeZoneDefinition tzd, string groupId, TimeZoneInfo tzInfo, TimeZoneInfo.AdjustmentRule adjustmentRule)
+        {
+            TimeZoneTransitionGroup transitionGroup;
+
+            Assert.IsTrue(tzd.TransitionGroups.TryGetValue(groupId, out transitionGroup), "The transition group was not found in the time zone definition.");
+            if (adjustmentRule != null)
+            {
+                if (adjustmentRule.DaylightDelta != TimeSpan.Zero)
+                {
+                    Assert.IsTrue(adjustmentRule.DaylightTransitionStart.HasSameDate(adjustmentRule.DaylightTransitionEnd), "Period transition groups must not be associated with an adjustment rule that has DST enabled unless the DST period starts and ends on the same day.");
+                }
+            }
+            Assert.AreEqual(1, transitionGroup.Transitions.Count, "A period transition group should have only one transition.");
+
+            TimeZoneTransition transition = transitionGroup.Transitions[0];
+
+            Assert.IsNotNull(transition.TargetPeriod, "A transition within a transition group must contain a period.");
+
+            Assert.AreEqual(TimeZonePeriodType.Standard, ValidateTimeZonePeriod(tzd, transition.TargetPeriod.Id, tzInfo, adjustmentRule), "The periods within a period transition must be a standard period.");
+
+            Assert.IsInstanceOfType(transition, typeof(TimeZoneTransition), "The transition within a period transition group must be a standard transition.");
+        }
+
+        /// <summary>
+        /// Helper function to verify that two TimeZoneTransition structures represent different days of the year.
+        /// </summary>
+        /// <param name="transition1">The first transition date to verify.</param>
+        /// <param name="transition2">The second transition date to verify.</param>
+        private void VerifyTransitionsAreOnDifferentDays(TimeZoneTransition transition1, TimeZoneTransition transition2)
+        {
+            if (transition1.GetType() != transition2.GetType())
+            {
+                // Assume that if the transitions are different types, they are on different days.
+                return;
+            }
+
+            if (transition1 is AbsoluteDayOfMonthTransition)
+            {
+                var absTransition1 = transition1 as AbsoluteDayOfMonthTransition;
+                var absTransition2 = transition2 as AbsoluteDayOfMonthTransition;
+
+                Assert.IsFalse((absTransition1.Month == absTransition2.Month) && (absTransition1.DayOfMonth == absTransition2.DayOfMonth), "Daylight start and end date must not be the same.");
+            }
+            else if (transition1 is RelativeDayOfMonthTransition)
+            {
+                var relTransition1 = transition1 as RelativeDayOfMonthTransition;
+                var relTransition2 = transition2 as RelativeDayOfMonthTransition;
+
+                Assert.IsFalse((relTransition1.Month == relTransition2.Month) 
+                    && (relTransition1.WeekIndex == relTransition2.WeekIndex)
+                    && (relTransition1.DayOfTheWeek == relTransition2.DayOfTheWeek), 
+                    "Daylight start and end date must not be the same.");
+            }
+            else if (transition1 is AbsoluteDateTransition)
+            {
+                var absTransition1 = transition1 as AbsoluteDateTransition;
+                var absTransition2 = transition2 as AbsoluteDateTransition;
+
+                Assert.IsFalse((absTransition1.DateTime.Year == absTransition2.DateTime.Year)
+                    && (absTransition1.DateTime.Month == absTransition2.DateTime.Month) 
+                    && (absTransition1.DateTime.Day == absTransition2.DateTime.Day), 
+                    "Daylight start and end date must not be the same.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the TimeZoneDefinition contains the transition group identified by the provided ID string, 
+        /// and that the transition group represents a year with a DST period and that the group
+        /// matches the values in the specified TimeZoneInfo object and optionally a specific AdjustmentRule.
+        /// </summary>
+        /// <param name="tzd">The TimeZoneDefinion object containing the transition group to validate.</param>
+        /// <param name="groupId">The ID of the transition group to validate.</param>
+        /// <param name="tzInfo">The TimeZoneInfo object used to construct the TimeZoneDefinition object.</param>
+        /// <param name="adjustmentRule">The adjustment rule that applies to the transition group being validated.</param>
+        private void ValidateDaylightTransitionGroup(TimeZoneDefinition tzd, string groupId, TimeZoneInfo tzInfo, TimeZoneInfo.AdjustmentRule adjustmentRule)
+        {
+            TimeZoneTransitionGroup transitionGroup;
+
+            Assert.IsTrue(tzd.TransitionGroups.TryGetValue(groupId, out transitionGroup), "The transition group was not found in the time zone definition.");
+            Assert.IsNotNull(adjustmentRule, "Transition groups must be associated with an adjustment rule.");
+            Assert.AreNotEqual(TimeSpan.Zero, adjustmentRule.DaylightDelta, "Transition groups must be associated with an adjustment rule that has DST enabled.");
+            Assert.AreEqual(2, transitionGroup.Transitions.Count, "A transition group should have two transitions.");
+
+            VerifyTransitionsAreOnDifferentDays(transitionGroup.Transitions[0], transitionGroup.Transitions[1]);
+
+            TimeZonePeriodType[] timeZonePeriodTypes = new TimeZonePeriodType[2];
+
+            for (int ix=0; ix<2; ix++)
+            {
+                TimeZoneTransition transition = transitionGroup.Transitions[ix];
+
+                Assert.IsNotNull(transition.TargetPeriod, "A transition within a transition group must contain a period.");
+
+                timeZonePeriodTypes[ix] = ValidateTimeZonePeriod(tzd, transition.TargetPeriod.Id, tzInfo, adjustmentRule);
+
+                if (transition is AbsoluteDayOfMonthTransition)
+                {
+                    var absTransition = transition as AbsoluteDayOfMonthTransition;
+                    if (timeZonePeriodTypes[ix] == TimeZonePeriodType.Standard)
+                    {
+                        Assert.IsTrue(adjustmentRule.DaylightTransitionEnd.IsFixedDateRule, "Standard transition should not be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionEnd.DayOfWeek, 0, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.Month, absTransition.Month, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.Day, absTransition.DayOfMonth, "Standard transition has the wrong DayOfMonth.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.TimeOfDay.TimeOfDay, absTransition.TimeOffset, "Standard transition has the wrong time offset.");
+                    }
+                    else
+                    {
+                        Assert.IsTrue(adjustmentRule.DaylightTransitionStart.IsFixedDateRule, "Daylight transition should not be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionStart.DayOfWeek, 0, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.Month, absTransition.Month, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.Day, absTransition.DayOfMonth, "Daylight transition has the wrong WeekIndex.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.TimeOfDay.TimeOfDay, absTransition.TimeOffset, "Daylight transition has the wrong time offset.");
+                    }
+                }
+                else if (transition is RelativeDayOfMonthTransition)
+                {
+                    var relTransition = transition as RelativeDayOfMonthTransition;
+                    if (timeZonePeriodTypes[ix] == TimeZonePeriodType.Standard)
+                    {
+                        Assert.IsFalse(adjustmentRule.DaylightTransitionEnd.IsFixedDateRule, "Standard transition should be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionEnd.DayOfWeek, (int)relTransition.DayOfTheWeek, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.Month, relTransition.Month, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual((adjustmentRule.DaylightTransitionEnd.Week == 5) ? -1 : adjustmentRule.DaylightTransitionEnd.Week, relTransition.WeekIndex, "Standard transition has the wrong WeekIndex.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.TimeOfDay.TimeOfDay, relTransition.TimeOffset, "Standard transition has the wrong time offset.");
+                    }
+                    else
+                    {
+                        Assert.IsFalse(adjustmentRule.DaylightTransitionStart.IsFixedDateRule, "Daylight transition should be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionStart.DayOfWeek, (int)relTransition.DayOfTheWeek, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.Month, relTransition.Month, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual((adjustmentRule.DaylightTransitionStart.Week == 5) ? -1 : adjustmentRule.DaylightTransitionStart.Week, relTransition.WeekIndex, "Daylight transition has the wrong WeekIndex.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.TimeOfDay.TimeOfDay, relTransition.TimeOffset, "Daylight transition has the wrong time offset.");
+                    }
+                }
+                else if (transition is AbsoluteDateTransition)
+                {
+                    var absTransition = transition as AbsoluteDateTransition;
+                    if (timeZonePeriodTypes[ix] == TimeZonePeriodType.Standard)
+                    {
+                        Assert.IsTrue(adjustmentRule.DaylightTransitionEnd.IsFixedDateRule, "Standard transition should not be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionEnd.DayOfWeek, 0, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.Month, absTransition.DateTime.Month, "Standard transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.Day, absTransition.DateTime.Day, "Standard transition has the wrong DayOfMonth.");
+                        Assert.IsTrue(absTransition.DateTime.Year > 0, "Standard transition year is not set.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionEnd.TimeOfDay.TimeOfDay, absTransition.DateTime.TimeOfDay, "Standard transition has the wrong time offset.");
+                    }
+                    else
+                    {
+                        Assert.IsTrue(adjustmentRule.DaylightTransitionStart.IsFixedDateRule, "Daylight transition should not be a fixed date transition.");
+                        Assert.AreEqual((int)adjustmentRule.DaylightTransitionStart.DayOfWeek, 0, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.Month, absTransition.DateTime.Month, "Daylight transition has the wrong DayOfTheWeek.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.Day, absTransition.DateTime.Day, "Daylight transition has the wrong WeekIndex.");
+                        Assert.IsTrue(absTransition.DateTime.Year > 0, "Daylight transition year is not set.");
+                        Assert.AreEqual(adjustmentRule.DaylightTransitionStart.TimeOfDay.TimeOfDay, absTransition.DateTime.TimeOfDay, "Daylight transition has the wrong time offset.");
+                    }
+                }
+                else 
+                {
+                    Assert.Fail("Standard transitions are not allowed in a transition group.");
+                }
+            }
+
+            Assert.IsTrue(timeZonePeriodTypes[0] != timeZonePeriodTypes[1], "A time zone transition group must contain one standard period and one daylight period.");
+        }
+
+        /// <summary>
+        /// A helper function that will create a TimeZoneDefinition object from the provided TimeZoneInfo object and
+        /// verify that the Dynamic DST rules represented by the created TimeZoneDefinition object matches those
+        /// of the TimeZoneInfo object.
+        /// </summary>
+        /// <param name="timeZoneInfo">The TimeZoneInfo object representing the time zone to be tested.</param>
+        public void TestTimeZone(TimeZoneInfo timeZoneInfo)
+        {
+            TimeZoneDefinition tzd = new TimeZoneDefinition(timeZoneInfo);
+            var transitions = tzd.GetTransitions();
+            if ((transitions == null) || (transitions.Count < 1))
+            {
+                Assert.Fail("No transitions found.");
+            }
+
+            var adjustmentRules = timeZoneInfo.GetAdjustmentRules();
+            if (adjustmentRules.Length < 1)
+            {
+                adjustmentRules = null;
+            }
+            int adjustmentRuleIndex = -1;
+            TimeZoneInfo.AdjustmentRule lastAdjustmentRule = null;
+
+            foreach (var transition in transitions)
+            {
+                Assert.IsNull(transition.TargetPeriod, "Time zone transitions cannot reference time zone periods.");
+                Assert.IsNotNull(transition.TargetGroup, "Time zone transitions must referenca a time zone group.");
+
+                TimeZoneInfo.AdjustmentRule adjustmentRule = null;
+                if (transition.GetType() == typeof(TimeZoneTransition))
+                {
+                    if (adjustmentRules != null)
+                    {
+                        // If there are adjustment rules, the first rule will apply to the transition if the date on the rule is MinDate.Date
+                        if (adjustmentRules[0].DateStart == DateTime.MinValue.Date)
+                        {
+                            adjustmentRuleIndex = 0;
+                            adjustmentRule = adjustmentRules[adjustmentRuleIndex];
+                        }
+                    }
+                }
+                else if (transition.GetType() == typeof(AbsoluteDateTransition))
+                {
+                    AbsoluteDateTransition absTransition = (AbsoluteDateTransition)transition;
+
+                    Assert.IsNotNull(adjustmentRules, "The time zone definition cannot have any absolute date transitions if the time zone does not have any adjustment rules.");
+
+                    if (lastAdjustmentRule != null)
+                    {
+                        Assert.AreEqual(lastAdjustmentRule.DateEnd.AddDays(1), absTransition.DateTime, "The transition date should be the next day after the end of the previous adjustment rule.");
+
+                        if (adjustmentRuleIndex < (adjustmentRules.Length - 1))
+                        {
+                            if (absTransition.DateTime < adjustmentRules[adjustmentRuleIndex + 1].DateStart)
+                            {
+                                // We have a hole in between the adjustment rules.
+                                adjustmentRule = null;
+                            }
+                            else if (absTransition.DateTime == adjustmentRules[adjustmentRuleIndex + 1].DateStart)
+                            {
+                                adjustmentRule = adjustmentRules[++adjustmentRuleIndex];
+                            }
+                            else
+                            {
+                                // Should not be possible, but just in case.
+                                Assert.Fail("The transition start date cannot be greater than the next available adjustment rule.");
+                            }
+                        }
+                        else
+                        {
+                            adjustmentRule = null;
+                        }
+                    }
+                    else
+                    {
+                        if (adjustmentRuleIndex < (adjustmentRules.Length - 1))
+                        {
+                            if (absTransition.DateTime < adjustmentRules[adjustmentRuleIndex + 1].DateStart)
+                            {
+                                Assert.Fail("A transition found with a start date that is less than the next available adjustment rule.");
+                            }
+                            else if (absTransition.DateTime == adjustmentRules[adjustmentRuleIndex + 1].DateStart)
+                            {
+                                adjustmentRule = adjustmentRules[++adjustmentRuleIndex];
+                            }
+                            else
+                            {
+                                // Should not be possible, but just in case.
+                                Assert.Fail("The transition start date cannot be greater than the next available adjustment rule.");
+                            }
+                        }
+                        else
+                        {
+                            Assert.Fail("A transition found with no more adjustment rules to pick from.");
+                        }
+                    }
+                }
+                else
+                {
+                    Assert.Fail("Unexpected transition type in the transition collection.");
+                }
+
+                if (transition.TargetGroup.SupportsDaylight)
+                {
+                    ValidateDaylightTransitionGroup(tzd, transition.TargetGroup.Id, timeZoneInfo, adjustmentRule);
+                }
+                else
+                {
+                    ValidateStandardTransitionGroup(tzd, transition.TargetGroup.Id, timeZoneInfo, adjustmentRule);
+                }
+
+                lastAdjustmentRule = adjustmentRule;
+            }
+
+            if (adjustmentRules != null)
+            {
+                Assert.AreEqual(adjustmentRules.Length - 1, adjustmentRuleIndex, "There are unprocessed adjustment rules in the time zone.");
+            }
+
+            if (lastAdjustmentRule != null)
+            {
+                // If the last transition corresponds with an adjustment rule, the adjustment rule should terminate with the Max date value.
+                Assert.AreEqual(DateTime.MaxValue.Date, lastAdjustmentRule.DateEnd, "The last adjustment rule does not end with the max date value. An additional transition should have been created.");
+            }
+        }
+
+        /// <summary>
+        /// A unit test that tests the creation of a TimeZoneDefinion object for every time zone known to the .Net runtime.
+        /// </summary>
+        [TestMethod]
+        public void TimeZoneTest_TimeZoneDefinitions()
+        {
+            int failureCount = 0;
+            foreach (TimeZoneInfo timeZoneInfo in TimeZoneInfo.GetSystemTimeZones())
+            {
+                try
+                {
+                    TestTimeZone(timeZoneInfo);
+                }
+                catch(Exception err)
+                {
+                    //Assert.Fail("The time zone '{0}' failed with error [{1}].", timeZoneInfo.Id, err.Message);
+                    Debug.Print("The time zone '{0}' failed with error [{1}].", timeZoneInfo.Id, err.Message);
+                    failureCount++;
+                }
+            }
+
+            Assert.AreEqual(0, failureCount, "One or more time zones failed the TimeZoneDefinition test.");
+        }
+
+        /// <summary>
+        /// This test is useful for when you need to step through the creation of a specific time zone definition.
+        /// It is here for debugging purposes only, which is why it has the [Ignore] attribute.
+        /// </summary>
+        [Ignore]
+        [TestMethod]
+        public void TimeZoneTest_TimeZoneDefinition()
+        {
+            TestTimeZone(TimeZoneInfo.GetSystemTimeZones().Single(x => x.Id == "Venezuela Standard Time"));
+        }
+    }
+}

--- a/Microsoft.Exchange.WebServices.Data.csproj
+++ b/Microsoft.Exchange.WebServices.Data.csproj
@@ -96,6 +96,7 @@
     <Compile Include="ComplexProperties\PeopleInsights\StringInsightValue.cs" />
     <Compile Include="ComplexProperties\PeopleInsights\UserProfilePicture.cs" />
     <Compile Include="ComplexProperties\ReferenceAttachment.cs" />
+    <Compile Include="ComplexProperties\TimeZones\TimeZoneInfoExtensionMethods.cs" />
     <Compile Include="Core\Requests\GetOMEConfigurationRequest.cs" />
     <Compile Include="Core\Requests\GetPeopleInsightsRequest.cs" />
     <Compile Include="Core\Requests\SetUserPhotoRequest.cs" />
@@ -879,41 +880,23 @@
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets. -->
   <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-
     <ParameterGroup>
-
       <Url ParameterType="System.String" Required="true" />
-
       <FileName ParameterType="System.String" Required="true" />
-
     </ParameterGroup>
-
     <Task>
-
       <Reference Include="System" />
-
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
+      <Code Type="Fragment" Language="cs"><![CDATA[
 		
           new System.Net.WebClient().DownloadFile(Url, FileName);
 		  
-        ]]>
-      </Code>
-
+        ]]></Code>
     </Task>
-
   </UsingTask>
-
   <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
-
     <!-- Download nuget.exe if we need it -->
-
     <DownloadFile Condition="!Exists('$(OutputPath)\nuget.exe')" FileName="$(OutputPath)\nuget.exe" Url="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" />
-
     <!-- Pack up a nuget package -->
-
     <Exec Command="$(OutputPath)\nuget pack $(ProjectFileName) -Properties Configuration=Release -Symbols -OutputDirectory $(OutputPath) -IncludeReferencedProjects" />
-
   </Target>
- 
 </Project>

--- a/Microsoft.Exchange.WebServices.Data.sln
+++ b/Microsoft.Exchange.WebServices.Data.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8BBBEC00-BD81-4F37-A855-D338DC01E1C5}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Exchange.WebServices.Data", "Microsoft.Exchange.WebServices.Data.csproj", "{F059972F-0561-4203-ABB8-3ABB41CCBE22}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EwsManagedApiTest", "EwsManagedApiTest\EwsManagedApiTest.csproj", "{68BFE270-3677-422A-9394-C0D8FECDC28B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,6 +24,10 @@ Global
 		{F059972F-0561-4203-ABB8-3ABB41CCBE22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F059972F-0561-4203-ABB8-3ABB41CCBE22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F059972F-0561-4203-ABB8-3ABB41CCBE22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68BFE270-3677-422A-9394-C0D8FECDC28B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68BFE270-3677-422A-9394-C0D8FECDC28B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68BFE270-3677-422A-9394-C0D8FECDC28B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68BFE270-3677-422A-9394-C0D8FECDC28B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -24,6 +24,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // CLS Compliant
@@ -34,3 +35,4 @@ using System.Runtime.InteropServices;
 
 
 // Friend Assemblies: Add to AssemblyInfoMicrosoft.cs
+[assembly: InternalsVisibleTo("EwsManagedApiTest")]


### PR DESCRIPTION
- Some time zones are created with missing TimeZonePeriod objects, resulting in an invalid TimeZoneDefinition structure that is rejected by the EWS service.
- The TimeZoneDefinition constructor handles time zones with undefined years BEFORE the collection of AdjustmentRules and AFTER the collection of AdjustmentRules, but it does not handle gaps IN BETWEEN AdjustmentRules. For example, say you have an adjustment rule from 2009 to 2010 and the next adjustment rule is from 2012-1016. In between 2010 and 2012 is the year 2011. This missing year indicates that there was no DST period during 2011. There needs to be a TimeZoneTransition for 2011 to indicate that there is no DST for that year.
- Some time zones have years where the standard period BIAS is different than the base BIAS defined in the TimeZoneInfo object. This is indicated by an AdjustmentRule that has a non-zero BaseUtcOffsetDelta property. Currently the EWS library does not take this value into account. By not taking this value into account, the created TimeZoneDefinition will have periods where the defined BIAS for the period is incorrect.  NOTE that this is an internal property that can only be accessed through reflection.This issue only affects historical years. The current year is not affected (since the TimeZoneInfo object's bias is based on the current year), and at the time of this bug fix there are no time zones that have this problem for future years.
- The value written to the DateTime element on the AbsoluteDateTransition element is converted to UTC. The DateTime is primarily used to specify the start year for the transition. Converting the date to UTC may change the start year (depending on the time zone) that is written to XML. The date that is written to this element should not be converted to UTC.
- There is one time zone (Sao Tome Standard Time) that has a year with a DST period that lasts one hour. This time zone is rejected as an invalid time zone by EWS. The library was updated to treat years with DST periods lasting less than a day the same as years with no DST at all. This allows the time zone to be received by Exchange with no errors.
- Added a unit test project to unit test the conversion of TimeZoneInfo objects to TimeZoneDefinition objects.