### PR TITLE
Fix SCP pointer domain comparison

### DIFF
--- a/Autodiscover/DirectoryHelper.cs
+++ b/Autodiscover/DirectoryHelper.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Exchange.WebServices.Autodiscover
                         scpPtrLdapPath = scpDirEntry.Properties["serviceBindingInformation"][0] as string;
 
                         // If the SCP pointer matches the user's domain, then restart search from that point.
-                        if (entryKeywords.CaseInsensitiveContains(domainMatch))
+                        if (scpPtrLdapPath.CaseInsensitiveContains(domainMatch))
                         {
                             // Stop the current search, start another from a new location.
                             this.TraceMessage(


### PR DESCRIPTION
The keywords attribute contains a GUID. The domain should be compared against the serviceBindingInformation attribute. See 
- https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxdisco/a2757b8d-f43e-4e6e-a65d-8283a90a5de3