### PR TITLE
Fix round trip issue with some time zones

### DIFF
--- a/ComplexProperties/TimeZones/TimeZoneDefinition.cs
+++ b/ComplexProperties/TimeZones/TimeZoneDefinition.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Exchange.WebServices.Data
                     transitionToDummyGroup.DateTime = lastAdjustmentRuleEndDate.AddDays(1);
 
                     this.transitions.Add(transitionToDummyGroup);
+                    if(!this.periods.ContainsKey(standardPeriod.Id))
+	                    this.periods.Add(standardPeriod.Id, standardPeriod);
                 }
             }
         }


### PR DESCRIPTION
As referenced in issue #74 , some time zones are generating an XML output that fails the read procedure for the recipient. This is because of the attempt to add a transition to an open ended group when the last transition has a specified end date. This generally resulted in a transition to a period that had not been added to the TimeZoneDefinition. This change simply attempts to ensure that the period referenced by the open ended transition group exists for the TimeZoneDefinition.