### PR TITLE
Fix issue with parsing GetInboxRulesResponse

### DIFF
--- a/ComplexProperties/TimeZones/TimeZoneDefinition.cs
+++ b/ComplexProperties/TimeZones/TimeZoneDefinition.cs
@@ -179,8 +179,6 @@ namespace Microsoft.Exchange.WebServices.Data
                     transitionToDummyGroup.DateTime = lastAdjustmentRuleEndDate.AddDays(1);
 
                     this.transitions.Add(transitionToDummyGroup);
-                    if(!this.periods.ContainsKey(standardPeriod.Id))
-	                    this.periods.Add(standardPeriod.Id, standardPeriod);
                 }
             }
         }

--- a/ComplexProperties/TimeZones/TimeZoneDefinition.cs
+++ b/ComplexProperties/TimeZones/TimeZoneDefinition.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Exchange.WebServices.Data
                     transitionToDummyGroup.DateTime = lastAdjustmentRuleEndDate.AddDays(1);
 
                     this.transitions.Add(transitionToDummyGroup);
+                    if(!this.periods.ContainsKey(standardPeriod.Id))
+	                    this.periods.Add(standardPeriod.Id, standardPeriod);
                 }
             }
         }

--- a/Core/Responses/GetInboxRulesResponse.cs
+++ b/Core/Responses/GetInboxRulesResponse.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Exchange.WebServices.Data
                 XmlNamespace.Messages, 
                 XmlElementNames.OutlookRuleBlobExists);
             reader.Read();
-            if (reader.IsStartElement(XmlNamespace.NotSpecified, XmlElementNames.InboxRules))
+            if (reader.IsStartElement(XmlNamespace.Messages, XmlElementNames.InboxRules))
             {
-                this.ruleCollection.LoadFromXml(reader, XmlNamespace.NotSpecified, XmlElementNames.InboxRules);
+                this.ruleCollection.LoadFromXml(reader, XmlNamespace.Messages, XmlElementNames.InboxRules);
             }
         }
 


### PR DESCRIPTION
When parsing GetInboxRulesResponse from XML, the namespace for the InboxRules element is not specified, which can cause problems with third party EWS store providers. Instead, look for InboRules using the messages namespace.