### PR TITLE
Update EwsUtilities.cs

### DIFF
--- a/Core/EwsUtilities.cs
+++ b/Core/EwsUtilities.cs
@@ -406,7 +406,7 @@ namespace Microsoft.Exchange.WebServices.Data
             writer.WriteStartElement("Trace");
             writer.WriteAttributeString("Tag", traceTag);
             writer.WriteAttributeString("Tid", Thread.CurrentThread.ManagedThreadId.ToString());
-            writer.WriteAttributeString("Time", DateTime.UtcNow.ToString("u", DateTimeFormatInfo.InvariantInfo));
+            writer.WriteAttributeString("Time", DateTime.UtcNow.ToString("O", DateTimeFormatInfo.InvariantInfo));
 
             if (includeVersion)
             {


### PR DESCRIPTION
Change the Time attribute in the trace tag to format "O" from "u", so that we capture fractions of a second too.  Without this, we need to analyze the headers of the responses to get this information.  This is important when tracing applications that can generate hundreds of requests in the same second.